### PR TITLE
fix: show no IV detail modal when going to detail page

### DIFF
--- a/src/components/subscription/invoicesTab.tsx
+++ b/src/components/subscription/invoicesTab.tsx
@@ -247,16 +247,14 @@ const Index = ({
       dataIndex: 'invoiceId',
       key: 'invoiceId',
       render: (ivId) => (
-        <div className="flex items-center">
+        <div className="invoice-id-wrapper flex items-center">
           <a
             href={`${location.origin}${BASE_PATH}invoice/${ivId}`}
             style={{ fontFamily: 'monospace' }}
           >
             {ivId}
           </a>
-          <span className="btn-copy-to-clipboard">
-            <CopyToClipboard content={ivId} />
-          </span>
+          <CopyToClipboard content={ivId} />
         </div>
       )
     },
@@ -552,7 +550,7 @@ const Index = ({
                 setInvoiceIdx(rowIndex as number)
                 if (
                   event.target instanceof Element &&
-                  event.target.closest('.btn-copy-to-clipboard') != null
+                  event.target.closest('.invoice-id-wrapper') != null
                 ) {
                   return
                 }

--- a/src/components/user/promoCreditTxHist.tsx
+++ b/src/components/user/promoCreditTxHist.tsx
@@ -269,9 +269,21 @@ const Index = ({
     },
     {
       title: 'Notes',
-      dataIndex: 'name',
-      key: 'name',
-      render: (note, tx) => <Tooltip title={tx.description}>{note}</Tooltip>
+      dataIndex: 'description',
+      key: 'description',
+      width: 128,
+      render: (note, tx) => (
+        <div
+          style={{
+            width: 128,
+            textOverflow: 'ellipsis',
+            overflow: 'hidden',
+            whiteSpace: 'nowrap'
+          }}
+        >
+          <Tooltip title={tx.description}>{note}</Tooltip>
+        </div>
+      )
     },
     {
       title: 'By',


### PR DESCRIPTION
<!--
Before submitting this pull request:

- Make sure you have read the [contributing guidelines](#)
- It should pass all tests in the available GitHub actions
- You should add/modify tests to cover your proposed code changes
- If your pull request contains a new feature, please document it on the README
-->

## Summary of changes
don't show IV detail modal when click to go to detail page
show creditTxNote by reading description not name

## Other information
<!-- Other useful information -->
