### PR TITLE
feat: go-back in ivDetail will go to where it came from with pageNum

### DIFF
--- a/src/hooks/useAppInitialize.ts
+++ b/src/hooks/useAppInitialize.ts
@@ -86,7 +86,7 @@ export const useAppInitialize = (): (() => Promise<string>) => {
     } else if (permissions.has('invoice')) {
       return '/invoice'
     } else {
-      return Array.from(permissions)[0] ?? '/'
+      return '/' + (Array.from(permissions)[0] ?? '')
     }
   }, [appConfigStore, merchantInfoStore, productsStore, creditConfigStore])
 


### PR DESCRIPTION
<!--
Before submitting this pull request:

- Make sure you have read the [contributing guidelines](#)
- It should pass all tests in the available GitHub actions
- You should add/modify tests to cover your proposed code changes
- If your pull request contains a new feature, please document it on the README
-->

## Summary of changes
- fix: non-owner still face blank page if their accessible pages are not one of /user, /invoice, /subscription

## Other information
<!-- Other useful information -->
