### PR TITLE
fix: hide archived plans in PlanSelector except user subscribed to it

### DIFF
--- a/src/components/subscription/modals/changePlan.tsx
+++ b/src/components/subscription/modals/changePlan.tsx
@@ -12,6 +12,7 @@ import {
   IPreview,
   IProfile,
   ISubscriptionType,
+  PlanStatus,
   TPromoAccount
 } from '../../../shared.types'
 import { useAppConfigStore } from '../../../stores'
@@ -225,6 +226,12 @@ const ChangePlan = ({
           selectedPlanId={selectedPlanId}
           productId={subInfo!.productId}
           onPlanSelected={(p: IPlan) => setSelectedPlan(p.id)}
+          filterPredicate={
+            (p) =>
+              (p?.status != PlanStatus.SOFT_ARCHIVED &&
+                p?.status != PlanStatus.HARD_ARCHIVED) ||
+              p?.id == subInfo?.plan?.id // it's possible users have subscribed to an archived plan. Selector need to show this plan.
+          }
         />
       </div>
 

--- a/src/components/user/assignSub/assignSubModal.tsx
+++ b/src/components/user/assignSub/assignSubModal.tsx
@@ -30,6 +30,7 @@ import {
   DiscountType,
   IPlan,
   IProfile,
+  PlanStatus,
   TPromoAccount,
   WithDoubleConfirmFields
 } from '../../../shared.types'
@@ -487,6 +488,10 @@ export const AssignSubscriptionModal = ({
               productId={productId}
               selectedPlanId={
                 selectedPlan == undefined ? null : selectedPlan.id
+              }
+              filterPredicate={(p) =>
+                p?.status != PlanStatus.SOFT_ARCHIVED &&
+                p?.status != PlanStatus.HARD_ARCHIVED
               }
             />
 


### PR DESCRIPTION
<!--
Before submitting this pull request:

- Make sure you have read the [contributing guidelines](#)
- It should pass all tests in the available GitHub actions
- You should add/modify tests to cover your proposed code changes
- If your pull request contains a new feature, please document it on the README
-->

## Summary of changes
- fix: hide archived plans in <PlanSelector /> except when users have subscribed to it.

## Other information
<!-- Other useful information -->
