### PR TITLE
fix: refresh subdetail tab when userProfile changed due to searchResu…

### DIFF
--- a/src/components/user/productList.tsx
+++ b/src/components/user/productList.tsx
@@ -41,7 +41,7 @@ const Index = ({
 
   useEffect(() => {
     getProductList()
-  }, [])
+  }, [userId])
 
   return (
     <>

--- a/src/components/user/subscriptionTab.tsx
+++ b/src/components/user/subscriptionTab.tsx
@@ -77,7 +77,7 @@ const Index = ({
 
   useEffect(() => {
     getSubInProduct()
-  }, [productId])
+  }, [productId, userId])
 
   useEffect(() => {
     if (refreshSub) {


### PR DESCRIPTION
…lt clicking

<!--
Before submitting this pull request:

- Make sure you have read the [contributing guidelines](#)
- It should pass all tests in the available GitHub actions
- You should add/modify tests to cover your proposed code changes
- If your pull request contains a new feature, please document it on the README
-->

## Summary of changes
- fix: user profile changed(admin click one of user from app search list), should update the user/detail page.

## Other information
<!-- Other useful information -->
